### PR TITLE
Update github url from 'manuelschneid3r' to 'albertlauncher'

### DIFF
--- a/2017/01/09/albert-now-has-a-website.html
+++ b/2017/01/09/albert-now-has-a-website.html
@@ -45,7 +45,7 @@
         <a href="/help/">Help</a>
     </li>
     <li>
-        <a href="https://github.com/manuelschneid3r/albert.git"><span class="hide-on-mobiles">View on </span>GitHub</a>
+        <a href="https://github.com/albertlauncher/albert"><span class="hide-on-mobiles">View on </span>GitHub</a>
     </li>
 </ul>
 

--- a/2017/01/11/repository-moved-to-organization.html
+++ b/2017/01/11/repository-moved-to-organization.html
@@ -45,7 +45,7 @@
         <a href="/help/">Help</a>
     </li>
     <li>
-        <a href="https://github.com/manuelschneid3r/albert.git"><span class="hide-on-mobiles">View on </span>GitHub</a>
+        <a href="https://github.com/albertlauncher/albert"><span class="hide-on-mobiles">View on </span>GitHub</a>
     </li>
 </ul>
 

--- a/2017/01/17/albert-v00.9.0-released.html
+++ b/2017/01/17/albert-v00.9.0-released.html
@@ -45,7 +45,7 @@
         <a href="/help/">Help</a>
     </li>
     <li>
-        <a href="https://github.com/manuelschneid3r/albert.git"><span class="hide-on-mobiles">View on </span>GitHub</a>
+        <a href="https://github.com/albertlauncher/albert"><span class="hide-on-mobiles">View on </span>GitHub</a>
     </li>
 </ul>
 

--- a/2017/01/23/albert-v0.9.1-released.html
+++ b/2017/01/23/albert-v0.9.1-released.html
@@ -45,7 +45,7 @@
         <a href="/help/">Help</a>
     </li>
     <li>
-        <a href="https://github.com/manuelschneid3r/albert.git"><span class="hide-on-mobiles">View on </span>GitHub</a>
+        <a href="https://github.com/albertlauncher/albert"><span class="hide-on-mobiles">View on </span>GitHub</a>
     </li>
 </ul>
 

--- a/docs/changelog/index.html
+++ b/docs/changelog/index.html
@@ -45,7 +45,7 @@
         <a href="/help/">Help</a>
     </li>
     <li>
-        <a href="https://github.com/manuelschneid3r/albert.git"><span class="hide-on-mobiles">View on </span>GitHub</a>
+        <a href="https://github.com/albertlauncher/albert"><span class="hide-on-mobiles">View on </span>GitHub</a>
     </li>
 </ul>
 

--- a/docs/contributing/index.html
+++ b/docs/contributing/index.html
@@ -45,7 +45,7 @@
         <a href="/help/">Help</a>
     </li>
     <li>
-        <a href="https://github.com/manuelschneid3r/albert.git"><span class="hide-on-mobiles">View on </span>GitHub</a>
+        <a href="https://github.com/albertlauncher/albert"><span class="hide-on-mobiles">View on </span>GitHub</a>
     </li>
 </ul>
 
@@ -149,7 +149,7 @@ However, the maintainer hears: <em>“I wrote some code. I’d like you to test,
   <li>Spread the word!</li>
   <li>Join the community and help other users.</li>
   <li>Use the application and report issues.</li>
-  <li>Check the issues tracker and try to help debugging. <a href="https://github.com/ManuelSchneid3r/albert/issues"><img src="https://img.shields.io/github/issues/manuelschneid3r/albert.svg" alt="Issues" /></a></li>
+  <li>Check the issues tracker and try to help debugging. <a href="https://github.com/albertlauncher/albert/issues"><img src="https://img.shields.io/github/issues/albertlauncher/albert.svg" alt="Issues" /></a></li>
   <li>Improve the documentation (Link on top of the pages).</li>
   <li>Support me as a creator by donating some bucks via <a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&amp;hosted_button_id=W74BQPKPGNSNC">paypal</a>,  <a href="https://flattr.com/submit/auto?user_id=manuelschneid3r&amp;url=https%3A%2F%2Fgithub.com%2FManuelSchneid3r%2Falbert">flattr</a> or <a href="https://www.patreon.com/albertlauncher">patreon</a>.</li>
 </ul>

--- a/docs/extending/external/index.html
+++ b/docs/extending/external/index.html
@@ -45,7 +45,7 @@
         <a href="/help/">Help</a>
     </li>
     <li>
-        <a href="https://github.com/manuelschneid3r/albert.git"><span class="hide-on-mobiles">View on </span>GitHub</a>
+        <a href="https://github.com/albertlauncher/albert"><span class="hide-on-mobiles">View on </span>GitHub</a>
     </li>
 </ul>
 

--- a/docs/extending/index.html
+++ b/docs/extending/index.html
@@ -45,7 +45,7 @@
         <a href="/help/">Help</a>
     </li>
     <li>
-        <a href="https://github.com/manuelschneid3r/albert.git"><span class="hide-on-mobiles">View on </span>GitHub</a>
+        <a href="https://github.com/albertlauncher/albert"><span class="hide-on-mobiles">View on </span>GitHub</a>
     </li>
 </ul>
 

--- a/docs/extending/javascript/index.html
+++ b/docs/extending/javascript/index.html
@@ -45,7 +45,7 @@
         <a href="/help/">Help</a>
     </li>
     <li>
-        <a href="https://github.com/manuelschneid3r/albert.git"><span class="hide-on-mobiles">View on </span>GitHub</a>
+        <a href="https://github.com/albertlauncher/albert"><span class="hide-on-mobiles">View on </span>GitHub</a>
     </li>
 </ul>
 

--- a/docs/extending/lua/index.html
+++ b/docs/extending/lua/index.html
@@ -45,7 +45,7 @@
         <a href="/help/">Help</a>
     </li>
     <li>
-        <a href="https://github.com/manuelschneid3r/albert.git"><span class="hide-on-mobiles">View on </span>GitHub</a>
+        <a href="https://github.com/albertlauncher/albert"><span class="hide-on-mobiles">View on </span>GitHub</a>
     </li>
 </ul>
 

--- a/docs/extending/native/index.html
+++ b/docs/extending/native/index.html
@@ -45,7 +45,7 @@
         <a href="/help/">Help</a>
     </li>
     <li>
-        <a href="https://github.com/manuelschneid3r/albert.git"><span class="hide-on-mobiles">View on </span>GitHub</a>
+        <a href="https://github.com/albertlauncher/albert"><span class="hide-on-mobiles">View on </span>GitHub</a>
     </li>
 </ul>
 
@@ -126,7 +126,7 @@
 </blockquote>
 
 <ol>
-  <li>Copy the template extension using the script in the <a href="https://github.com/ManuelSchneid3r/albert/tree/master/src/plugins">plugins folder</a>.</li>
+  <li>Copy the template extension using the script in the <a href="https://github.com/albertlauncher/albert/tree/master/src/plugins">plugins folder</a>.</li>
   <li>Adjust the values in <code class="highlighter-rouge">metadata.json</code> and <code class="highlighter-rouge">CmakeLists.txt</code>.</li>
   <li>Adjust the extension to your liking. Check the extension interface for members that you may or must implement.</li>
 </ol>

--- a/docs/extending/python/index.html
+++ b/docs/extending/python/index.html
@@ -45,7 +45,7 @@
         <a href="/help/">Help</a>
     </li>
     <li>
-        <a href="https://github.com/manuelschneid3r/albert.git"><span class="hide-on-mobiles">View on </span>GitHub</a>
+        <a href="https://github.com/albertlauncher/albert"><span class="hide-on-mobiles">View on </span>GitHub</a>
     </li>
 </ul>
 

--- a/docs/faq/index.html
+++ b/docs/faq/index.html
@@ -45,7 +45,7 @@
         <a href="/help/">Help</a>
     </li>
     <li>
-        <a href="https://github.com/manuelschneid3r/albert.git"><span class="hide-on-mobiles">View on </span>GitHub</a>
+        <a href="https://github.com/albertlauncher/albert"><span class="hide-on-mobiles">View on </span>GitHub</a>
     </li>
 </ul>
 

--- a/docs/home/index.html
+++ b/docs/home/index.html
@@ -45,7 +45,7 @@
         <a href="/help/">Help</a>
     </li>
     <li>
-        <a href="https://github.com/manuelschneid3r/albert.git"><span class="hide-on-mobiles">View on </span>GitHub</a>
+        <a href="https://github.com/albertlauncher/albert"><span class="hide-on-mobiles">View on </span>GitHub</a>
     </li>
 </ul>
 

--- a/docs/installing/index.html
+++ b/docs/installing/index.html
@@ -45,7 +45,7 @@
         <a href="/help/">Help</a>
     </li>
     <li>
-        <a href="https://github.com/manuelschneid3r/albert.git"><span class="hide-on-mobiles">View on </span>GitHub</a>
+        <a href="https://github.com/albertlauncher/albert"><span class="hide-on-mobiles">View on </span>GitHub</a>
     </li>
 </ul>
 

--- a/docs/theming/index.html
+++ b/docs/theming/index.html
@@ -45,7 +45,7 @@
         <a href="/help/">Help</a>
     </li>
     <li>
-        <a href="https://github.com/manuelschneid3r/albert.git"><span class="hide-on-mobiles">View on </span>GitHub</a>
+        <a href="https://github.com/albertlauncher/albert"><span class="hide-on-mobiles">View on </span>GitHub</a>
     </li>
 </ul>
 

--- a/docs/using/index.html
+++ b/docs/using/index.html
@@ -45,7 +45,7 @@
         <a href="/help/">Help</a>
     </li>
     <li>
-        <a href="https://github.com/manuelschneid3r/albert.git"><span class="hide-on-mobiles">View on </span>GitHub</a>
+        <a href="https://github.com/albertlauncher/albert"><span class="hide-on-mobiles">View on </span>GitHub</a>
     </li>
 </ul>
 

--- a/help/index.html
+++ b/help/index.html
@@ -45,7 +45,7 @@
         <a href="/help/">Help</a>
     </li>
     <li>
-        <a href="https://github.com/manuelschneid3r/albert.git"><span class="hide-on-mobiles">View on </span>GitHub</a>
+        <a href="https://github.com/albertlauncher/albert"><span class="hide-on-mobiles">View on </span>GitHub</a>
     </li>
 </ul>
 
@@ -70,7 +70,7 @@
 
 <p>For all of you that do not enjoy the using IRC or just want to be connectable on your mobile phone there is a Albert community chat on telegram.</p>
 
-<h5 id="github-repository"><a href="https://github.com/manuelschneid3r/albert">Github repository</a></h5>
+<h5 id="github-repository"><a href="https://github.com/albertlauncher/albert">Github repository</a></h5>
 
 <p>If you wonder why Albert does this and that check out the source code to see how things work under the hood. If you think you encountered a bug, file an issue or check if somebody did already.</p>
 

--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
         <a href="/help/">Help</a>
     </li>
     <li>
-        <a href="https://github.com/manuelschneid3r/albert.git"><span class="hide-on-mobiles">View on </span>GitHub</a>
+        <a href="https://github.com/albertlauncher/albert"><span class="hide-on-mobiles">View on </span>GitHub</a>
     </li>
 </ul>
 

--- a/news/index.html
+++ b/news/index.html
@@ -45,7 +45,7 @@
         <a href="/help/">Help</a>
     </li>
     <li>
-        <a href="https://github.com/manuelschneid3r/albert.git"><span class="hide-on-mobiles">View on </span>GitHub</a>
+        <a href="https://github.com/albertlauncher/albert"><span class="hide-on-mobiles">View on </span>GitHub</a>
     </li>
 </ul>
 


### PR DESCRIPTION
I was reading the docs and saw that since the github url change the docs were not updated. I hope you are ok with this pull request.